### PR TITLE
Fix modsnap for long-join project

### DIFF
--- a/bdb/cursor_ll.h
+++ b/bdb/cursor_ll.h
@@ -21,6 +21,8 @@
 
 #include <build/db.h>
 
+u_int32_t get_cursor_flags(const bdb_cursor_impl_t * const cur, const uint8_t cursor_is_pausible);
+
 enum berkdb_t {
     BERKDB_UNK = 0,
     BERKDB_REAL = 1,         /* persistent */

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -181,6 +181,14 @@ enum { AUTHENTICATE_READ = 1, AUTHENTICATE_WRITE = 2 };
 static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
                              struct sql_thread *thd);
 
+static void initialize_curtran_for_modsnap(cursor_tran_t * const curtran, const struct sqlclntstate * const clnt)
+{
+    curtran->modsnap_start_lsn.file = clnt->modsnap_start_lsn_file;
+    curtran->modsnap_start_lsn.offset = clnt->modsnap_start_lsn_offset;
+    curtran->last_checkpoint_lsn.file = clnt->last_checkpoint_lsn_file;
+    curtran->last_checkpoint_lsn.offset = clnt->last_checkpoint_lsn_offset;
+}
+
 CurRange *currange_new()
 {
     CurRange *rc = (CurRange *)malloc(sizeof(CurRange));
@@ -4933,7 +4941,12 @@ int sqlite3BtreeBeginTrans(Vdbe *vdbe, Btree *pBt, int wrflag, int *pSchemaVersi
         goto done;
     }
 
-    if ((clnt->dbtran.mode <= TRANLEVEL_RECOM || clnt->dbtran.mode == TRANLEVEL_MODSNAP) && wrflag == 0) { // read-only
+    // TODO: Don't open shadows for read-only modsnap txns.
+    // In order to make this optimization work, we still need to latch
+    // the initial versions of tables and use these latched versions to 
+    // fail on schema changes. This is currently handled in the shadow code
+    // but can be refactored out.
+    if ((clnt->dbtran.mode <= TRANLEVEL_RECOM) && wrflag == 0) { // read-only
         if (clnt->has_recording == 0 ||                        // not selectv
             clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS) { // singular selectv
             rc = SQLITE_OK;
@@ -8269,10 +8282,7 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
     }
     cur->tableversion = cur->db->tableversion;
 
-    clnt->dbtran.cursor_tran->modsnap_start_lsn.file = clnt->modsnap_start_lsn_file;
-    clnt->dbtran.cursor_tran->modsnap_start_lsn.offset = clnt->modsnap_start_lsn_offset;
-    clnt->dbtran.cursor_tran->last_checkpoint_lsn.file = clnt->last_checkpoint_lsn_file;
-    clnt->dbtran.cursor_tran->last_checkpoint_lsn.offset = clnt->last_checkpoint_lsn_offset;
+    initialize_curtran_for_modsnap(clnt->dbtran.cursor_tran, clnt);
 
     /* initialize the shadow, if any  */
     cur->shadtbl = osql_get_shadow_bydb(thd->clnt, cur->db);
@@ -9763,6 +9773,8 @@ retry:
         return -1;
     }
 
+    initialize_curtran_for_modsnap(curtran_out, clnt);
+
     if (!clnt->init_gen)
         clnt->init_gen = curgen;
 
@@ -10075,8 +10087,9 @@ static int recover_deadlock_flags_int(bdb_state_type *bdb_state,
         } else {
             rc = SQLITE_SCHEMA;
         }
-    } else
+    } else {
         rc = get_curtran_flags(thedb->bdb_env, clnt, curtran_flags);
+    }
 
     if (rc) {
         char *err;

--- a/tests/cldeadlock.test/lrl.options
+++ b/tests/cldeadlock.test/lrl.options
@@ -11,4 +11,3 @@ random_get_curtran_failures 8000
 setattr checkpointtime 20
 cache 512 mb
 nowatch
-set_snapshot_impl new

--- a/tests/sicomplex2.test/lrl.options
+++ b/tests/sicomplex2.test/lrl.options
@@ -3,4 +3,3 @@ table t2 t2.csc2
 round_robin_stripes
 enable_snapshot_isolation
 ssl_client_mode OPTIONAL
-set_snapshot_impl new

--- a/tests/sicountbug.test/lrl.options
+++ b/tests/sicountbug.test/lrl.options
@@ -2,4 +2,3 @@ table t1 t1.csc2
 round_robin_stripes
 enable_snapshot_isolation
 notimeout
-set_snapshot_impl new

--- a/tests/sicountbug2.test/lrl.options
+++ b/tests/sicountbug2.test/lrl.options
@@ -2,4 +2,3 @@ table t1 t1.csc2
 round_robin_stripes
 enable_snapshot_isolation
 ssl_client_mode OPTIONAL
-set_snapshot_impl new

--- a/tests/sirandtest.test/lrl.options
+++ b/tests/sirandtest.test/lrl.options
@@ -3,4 +3,3 @@ table t2 t2.csc2
 round_robin_stripes
 enable_snapshot_isolation
 ssl_client_mode OPTIONAL
-set_snapshot_impl new

--- a/tests/sirandtest2.test/lrl.options
+++ b/tests/sirandtest2.test/lrl.options
@@ -5,4 +5,3 @@ blobstripe
 round_robin_stripes
 enable_snapshot_isolation
 ssl_client_mode OPTIONAL
-set_snapshot_impl new

--- a/tests/snap_ha_retry.test/lrl.options
+++ b/tests/snap_ha_retry.test/lrl.options
@@ -5,4 +5,3 @@ setattr PRIVATE_BLKSEQ_ENABLED 1
 setattr MIN_KEEP_LOGS_AGE 300
 berkattr mempv_debug 1
 enable_snapshot_isolation
-set_snapshot_impl new

--- a/tests/truncatesc.test/lrl.options
+++ b/tests/truncatesc.test/lrl.options
@@ -9,4 +9,3 @@ physrep_register_interval 30
 verbose_physrep on
 online_recovery on
 ack_trace
-set_snapshot_impl new


### PR DESCRIPTION
- Turn off optimization to not open shadows for readonly modsnap transactions for now.
- Set modsnap cursor flag in codepaths where it was missing
- Set modsnap target lsn / last checkpoint lsn in codepaths where it was missing